### PR TITLE
feat: add `create` command and improve drop workflow with table counts

### DIFF
--- a/fuelrod_backup/adapters/base.py
+++ b/fuelrod_backup/adapters/base.py
@@ -21,6 +21,7 @@ class DbAdapter(ABC):
     supports_roles: bool = False
     supports_toc: bool = False
     supports_schema_drop: bool = False
+    supports_schema_create: bool = False
     dump_extension: str = ".dump"
 
     # ──────────────────────────────────────────────────────────────
@@ -64,6 +65,9 @@ class DbAdapter(ABC):
     def get_db_size(self, dbname: str) -> str:
         return "?"
 
+    def get_table_count(self, dbname: str, schema: str | None = None) -> str:
+        return "?"
+
     def get_user_schemas(self, dbname: str) -> list[str]:
         return []
 
@@ -81,6 +85,9 @@ class DbAdapter(ABC):
 
     def drop_schema(self, dbname: str, schema: str) -> None:
         raise NotImplementedError(f"{type(self).__name__} does not support drop_schema")
+
+    def create_schema(self, dbname: str, schema: str) -> None:
+        raise NotImplementedError(f"{type(self).__name__} does not support create_schema")
 
     def role_exists(self, role: str) -> bool:
         raise NotImplementedError(f"{type(self).__name__} does not support role_exists")

--- a/fuelrod_backup/adapters/mariadb.py
+++ b/fuelrod_backup/adapters/mariadb.py
@@ -195,6 +195,7 @@ class MariaDbAdapter(DbAdapter):
         include_schemas / exclude_schemas are table-level for MySQL.
         (MySQL has no schemas; schemas map to tables for basic filtering.)
         """
+        _validate_identifier(dbname, "database name")
         cfg = self._cfg
         base_args = [
             cfg.mysql_dump_cmd,
@@ -227,6 +228,7 @@ class MariaDbAdapter(DbAdapter):
         no_owner: bool,
     ) -> None:
         """Restore a .sql / .sql.gz / .zip dump into *dbname*."""
+        _validate_identifier(dbname, "database name")
         cfg = self._cfg
         suffix = dump_file.suffix.lower()
 

--- a/fuelrod_backup/adapters/mariadb.py
+++ b/fuelrod_backup/adapters/mariadb.py
@@ -288,6 +288,18 @@ class MariaDbAdapter(DbAdapter):
         except MariaDbError:
             return "?"
 
+    def get_table_count(self, dbname: str, schema: str | None = None) -> str:
+        try:
+            if schema:
+                return "?"
+            val = self._query_one(
+                "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s",
+                (dbname,),
+            )
+            return str(val) if val else "0"
+        except MariaDbError:
+            return "?"
+
     def db_exists(self, dbname: str) -> bool:
         return dbname in self.list_databases()
 

--- a/fuelrod_backup/adapters/mssql.py
+++ b/fuelrod_backup/adapters/mssql.py
@@ -245,6 +245,24 @@ class MssqlAdapter(DbAdapter):
         except MssqlError:
             return []
 
+    def get_table_count(self, dbname: str, schema: str | None = None) -> str:
+        try:
+            if schema:
+                val = self._query_one(
+                    "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = %s",
+                    (schema,),
+                    dbname=dbname,
+                )
+            else:
+                val = self._query_one(
+                    "SELECT COUNT(*) FROM information_schema.tables WHERE table_catalog = %s",
+                    (dbname,),
+                    dbname=dbname,
+                )
+            return str(val) if val else "0"
+        except MssqlError:
+            return "?"
+
     def db_exists(self, dbname: str) -> bool:
         val = self._query_one(
             "SELECT COUNT(*) FROM sys.databases WHERE name = %s",

--- a/fuelrod_backup/adapters/mssql.py
+++ b/fuelrod_backup/adapters/mssql.py
@@ -11,6 +11,7 @@ For restore, the .bak is first copied into the container, then RESTORE is run.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -195,7 +196,10 @@ class MssqlAdapter(DbAdapter):
         cfg = self._cfg
 
         if cfg.use_docker:
-            ctr_path = f"{cfg.mssql_backup_dir}/{dump_file.name}"
+            safe_name = os.path.basename(dump_file.name)
+            if not re.match(r"^[A-Za-z0-9_.-]+$", safe_name):
+                raise MssqlError(f"Unsafe backup file name: {dump_file.name}")
+            ctr_path = f"{cfg.mssql_backup_dir}/{safe_name}"
             subprocess.run(
                 ["docker", "cp", str(dump_file), f"{cfg.service}:{ctr_path}"],
                 check=True,

--- a/fuelrod_backup/adapters/postgres.py
+++ b/fuelrod_backup/adapters/postgres.py
@@ -14,6 +14,7 @@ class PostgresAdapter(DbAdapter):
     supports_roles: bool = True
     supports_toc: bool = True
     supports_schema_drop: bool = True
+    supports_schema_create: bool = True
     dump_extension: str = ".dump"
 
     def __init__(self, cfg: Config) -> None:
@@ -147,6 +148,9 @@ class PostgresAdapter(DbAdapter):
 
     def drop_schema(self, dbname: str, schema: str) -> None:
         self._runner.drop_schema(dbname, schema)
+
+    def create_schema(self, dbname: str, schema: str) -> None:
+        self._runner.create_schema(dbname, schema)
 
     def get_table_count(self, dbname: str, schema: str | None = None) -> str:
         return self._runner.get_table_count(dbname, schema)

--- a/fuelrod_backup/backup.py
+++ b/fuelrod_backup/backup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gzip
+import re
 import shutil
 import subprocess
 import sys
@@ -36,6 +37,19 @@ def _section(title: str) -> None:
 def _die(msg: str) -> None:
     console.print(f"[bold red]ERROR:[/] {msg}")
     sys.exit(1)
+
+
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_\- ]+$")
+
+
+def _validate_path_component(name: str, label: str = "name") -> str:
+    """Validate that *name* is safe to use as a filesystem path component."""
+    if not name or not _SAFE_PATH_RE.match(name):
+        _die(
+            f"Invalid {label} '{name}': only letters, digits, underscores, "
+            "hyphens, and spaces are permitted."
+        )
+    return name
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -148,7 +162,11 @@ def _backup_one(
         if task_id is not None:
             progress.update(task_id, description=desc)
 
+    _validate_path_component(db, "database name")
     db_dir = Path(cfg.backup_dir) / db
+    db_dir = db_dir.resolve()
+    if not str(db_dir).startswith(str(Path(cfg.backup_dir).resolve())):
+        _die(f"Path traversal detected for database '{db}'")
     db_dir.mkdir(parents=True, exist_ok=True)
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/fuelrod_backup/cli.py
+++ b/fuelrod_backup/cli.py
@@ -236,16 +236,6 @@ def test_connection(
         raise typer.Exit(code=1)
 
 
-def _default_config_path() -> Path:
-    """Return the default config path in the user's home/profile directory."""
-    import os
-    if os.name == "nt":
-        user_profile = os.environ.get("USERPROFILE")
-        if user_profile:
-            return Path(user_profile) / ".backup"
-    return Path.home() / ".backup"
-
-
 @app.command("init")
 def init_config(
         output: Annotated[
@@ -255,10 +245,10 @@ def init_config(
 ) -> None:
     """Create or update a .backup config file interactively."""
     from . import prompt as q
-    from .config import _find_config_file, _parse_env_file
+    from .config import _find_config_file, _parse_env_file, user_home_dir
 
     if output is None:
-        output = _default_config_path()
+        output = user_home_dir() / ".backup"
     output = output.resolve()
     updating = output.exists()
 

--- a/fuelrod_backup/cli.py
+++ b/fuelrod_backup/cli.py
@@ -245,10 +245,10 @@ def init_config(
 ) -> None:
     """Create or update a .backup config file interactively."""
     from . import prompt as q
-    from .config import _find_config_file, _parse_env_file, user_home_dir
+    from .config import _find_config_file, _parse_env_file, user_config_dir
 
     if output is None:
-        output = user_home_dir() / ".backup"
+        output = user_config_dir() / ".backup"
     output = output.resolve()
     updating = output.exists()
 
@@ -295,6 +295,7 @@ def init_config(
 # ──────────────────────────────────────────────────────────────────────────────
 
 def _write_config(output: Path, lines: list[str], updating: bool) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text("\n".join(lines), encoding="utf-8")
     try:
         output.chmod(0o600)

--- a/fuelrod_backup/cli.py
+++ b/fuelrod_backup/cli.py
@@ -177,6 +177,25 @@ def drop(
     run_drop(cfg)
 
 
+@app.command("create")
+def create(
+        use_docker: Annotated[bool | None, _DOCKER_OPT] = None,
+        db_type: Annotated[str | None, _DB_TYPE_OPT] = None,
+        config_file: Annotated[Path | None, _CONFIG_OPT] = None,
+) -> None:
+    """Interactively create a database or schema.
+
+    Creates a new database, or a new PostgreSQL schema inside
+    an existing database. Name confirmation is required.
+    """
+    from .create import run_create
+
+    _validate_db_type(db_type)
+    cfg = load_config(config_file, db_type_override=db_type)
+    _apply_docker_override(cfg, use_docker)
+    run_create(cfg)
+
+
 @app.command("test")
 def test_connection(
         use_docker: Annotated[bool | None, _DOCKER_OPT] = None,

--- a/fuelrod_backup/cli.py
+++ b/fuelrod_backup/cli.py
@@ -236,17 +236,29 @@ def test_connection(
         raise typer.Exit(code=1)
 
 
+def _default_config_path() -> Path:
+    """Return the default config path in the user's home/profile directory."""
+    import os
+    if os.name == "nt":
+        user_profile = os.environ.get("USERPROFILE")
+        if user_profile:
+            return Path(user_profile) / ".backup"
+    return Path.home() / ".backup"
+
+
 @app.command("init")
 def init_config(
         output: Annotated[
             Path,
             typer.Option("--output", "-o", help="Path for the config file.", dir_okay=False),
-        ] = Path(".backup"),
+        ] = None,
 ) -> None:
     """Create or update a .backup config file interactively."""
     from . import prompt as q
     from .config import _find_config_file, _parse_env_file
 
+    if output is None:
+        output = _default_config_path()
     output = output.resolve()
     updating = output.exists()
 

--- a/fuelrod_backup/config.py
+++ b/fuelrod_backup/config.py
@@ -108,7 +108,7 @@ def _find_config_file() -> Path | None:
     """
     Search for a config file, checking these locations in order:
 
-    1. User home directory (~/)   (.backup then .env) — Linux only
+    1. User home directory (~/)   (.backup then .env) — all operating systems
     2. Current working directory  (.backup then .env)
     3. Package project directory  (.backup then .env)
     4. Repo root / one level up   (.backup then .env)
@@ -120,10 +120,9 @@ def _find_config_file() -> Path | None:
     cwd = Path.cwd()
 
     search_dirs: list[Path] = []
-    if os.name == "posix":
-        home = Path.home()
-        if home not in (cwd, pkg_dir):
-            search_dirs.append(home)
+    home = Path.home()
+    if home not in (cwd, pkg_dir):
+        search_dirs.append(home)
 
     search_dirs.append(cwd)
     if pkg_dir not in search_dirs:

--- a/fuelrod_backup/config.py
+++ b/fuelrod_backup/config.py
@@ -108,10 +108,11 @@ def _find_config_file() -> Path | None:
     """
     Search for a config file, checking these locations in order:
 
-    1. User home directory (~/)   (.backup then .env) — all operating systems
-    2. Current working directory  (.backup then .env)
-    3. Package project directory  (.backup then .env)
-    4. Repo root / one level up   (.backup then .env)
+    1. User home directory          (.backup then .env)
+       Windows: %USERPROFILE%  |  macOS/Linux: ~/
+    2. Current working directory    (.backup then .env)
+    3. Package project directory    (.backup then .env)
+    4. Repo root / one level up     (.backup then .env)
 
     Returns the first file found, or None.
     """
@@ -120,7 +121,14 @@ def _find_config_file() -> Path | None:
     cwd = Path.cwd()
 
     search_dirs: list[Path] = []
-    home = Path.home()
+    if os.name == "nt":
+        user_profile = os.environ.get("USERPROFILE")
+        if user_profile:
+            home = Path(user_profile)
+        else:
+            home = Path.home()
+    else:
+        home = Path.home()
     if home not in (cwd, pkg_dir):
         search_dirs.append(home)
 

--- a/fuelrod_backup/config.py
+++ b/fuelrod_backup/config.py
@@ -104,6 +104,20 @@ def _parse_env_file(path: Path) -> dict[str, str]:
     return result
 
 
+def user_home_dir() -> Path:
+    """
+    Return the user's home/profile directory.
+
+    - Windows: ``%USERPROFILE%`` (falls back to ``Path.home()``)
+    - macOS/Linux: ``Path.home()`` (``~``)
+    """
+    if os.name == "nt":
+        user_profile = os.environ.get("USERPROFILE")
+        if user_profile:
+            return Path(user_profile)
+    return Path.home()
+
+
 def _find_config_file() -> Path | None:
     """
     Search for a config file, checking these locations in order:
@@ -121,14 +135,7 @@ def _find_config_file() -> Path | None:
     cwd = Path.cwd()
 
     search_dirs: list[Path] = []
-    if os.name == "nt":
-        user_profile = os.environ.get("USERPROFILE")
-        if user_profile:
-            home = Path(user_profile)
-        else:
-            home = Path.home()
-    else:
-        home = Path.home()
+    home = user_home_dir()
     if home not in (cwd, pkg_dir):
         search_dirs.append(home)
 

--- a/fuelrod_backup/config.py
+++ b/fuelrod_backup/config.py
@@ -104,45 +104,53 @@ def _parse_env_file(path: Path) -> dict[str, str]:
     return result
 
 
-def user_home_dir() -> Path:
+def user_config_dir() -> Path:
     """
-    Return the user's home/profile directory.
+    Return the user-scoped config directory for fuelrod-backup.
 
-    - Windows: ``%USERPROFILE%`` (falls back to ``Path.home()``)
-    - macOS/Linux: ``Path.home()`` (``~``)
+    - Windows: ``%APPDATA%\\fuelrod-backup``
+    - macOS/Linux: ``$XDG_CONFIG_HOME/fuelrod-backup`` (defaults to ``~/.config/fuelrod-backup``)
     """
     if os.name == "nt":
-        user_profile = os.environ.get("USERPROFILE")
-        if user_profile:
-            return Path(user_profile)
-    return Path.home()
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "fuelrod-backup"
+        fallback = os.environ.get("USERPROFILE")
+        if fallback:
+            return Path(fallback) / "AppData" / "Roaming" / "fuelrod-backup"
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg) / "fuelrod-backup"
+    return Path.home() / ".config" / "fuelrod-backup"
 
 
 def _find_config_file() -> Path | None:
     """
     Search for a config file, checking these locations in order:
 
-    1. User home directory          (.backup then .env)
-       Windows: %USERPROFILE%  |  macOS/Linux: ~/
-    2. Current working directory    (.backup then .env)
-    3. Package project directory    (.backup then .env)
-    4. Repo root / one level up     (.backup then .env)
+    1. User config directory     (.backup then .env)
+       Windows: %APPDATA%\\fuelrod-backup  |  macOS/Linux: ~/.config/fuelrod-backup
+    2. Home directory root       (~/.backup then ~/.env)  — backward compat
+    3. Current working directory (.backup then .env)
+    4. Package project directory (.backup then .env)
+    5. Repo root / one level up  (.backup then .env)
 
     Returns the first file found, or None.
     """
     pkg_dir = Path(__file__).parent.parent  # fuelrod-backup/
     repo_root = pkg_dir.parent  # proxy-tool/
     cwd = Path.cwd()
+    home = Path.home()
 
     search_dirs: list[Path] = []
-    home = user_home_dir()
-    if home not in (cwd, pkg_dir):
+    search_dirs.append(user_config_dir())
+    if home not in search_dirs:
         search_dirs.append(home)
-
-    search_dirs.append(cwd)
+    if cwd not in search_dirs:
+        search_dirs.append(cwd)
     if pkg_dir not in search_dirs:
         search_dirs.append(pkg_dir)
-    if repo_root != cwd and repo_root != pkg_dir:
+    if repo_root not in search_dirs:
         search_dirs.append(repo_root)
 
     for directory in search_dirs:

--- a/fuelrod_backup/create.py
+++ b/fuelrod_backup/create.py
@@ -1,0 +1,215 @@
+"""Create wizard: interactively create a database or a PostgreSQL schema."""
+
+from __future__ import annotations
+
+import sys
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from rich.table import Column, Table
+
+from . import prompt as questionary
+from .adapters import get_adapter
+from .adapters.base import DbAdapter
+from .config import Config
+
+console = Console()
+
+
+def _section(title: str) -> None:
+    console.print()
+    console.rule(f"[bold green]{title}[/]")
+    console.print()
+
+
+def _die(msg: str) -> None:
+    console.print(f"[bold red]ERROR:[/] {msg}")
+    sys.exit(1)
+
+
+def run_create(cfg: Config) -> None:
+    """Interactive wizard to create a database or schema."""
+    adapter = get_adapter(cfg)
+
+    if not cfg.password:
+        _die("Password is required. Set the appropriate *_PASSWORD variable in .backup.")
+
+    console.print()
+    console.print(Panel(
+        f"[bold green]CREATE WIZARD — {cfg.db_type.value.upper()}[/]",
+        expand=False,
+    ))
+
+    # ── Connection ─────────────────────────────────────────────────
+    _section("Connection")
+    console.print(f"  Engine: [cyan]{cfg.db_type.value}[/]")
+    if cfg.use_docker:
+        console.print(f"  Mode  : [cyan]Docker[/] — service '[bold]{cfg.service}[/]'")
+    else:
+        console.print(f"  Mode  : Direct — {cfg.host}:{cfg.port}")
+    console.print(f"  User  : {cfg.user}")
+    console.print()
+    try:
+        questionary.check_connection_with_countdown(adapter.check_connection, cfg.connection_timeout)
+    except TimeoutError as exc:
+        _die(str(exc))
+    console.print("[green]Connection OK.[/]")
+
+    # ── Choose target type ─────────────────────────────────────────
+    _section("Create Target")
+
+    choices = [questionary.Choice("Database", value="database")]
+    if adapter.supports_schema_create:
+        choices.append(questionary.Choice(
+            "Schema    (CREATE SCHEMA inside an existing database)",
+            value="schema",
+        ))
+
+    if len(choices) == 1:
+        target_type = "database"
+        console.print("[dim]Only 'database' creation is supported for this engine.[/]")
+    else:
+        target_type = questionary.select("What do you want to create?", choices=choices).ask()
+
+    if target_type == "schema":
+        _create_schema(cfg, adapter)
+    else:
+        _create_database(cfg, adapter)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+#  Database creation
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _create_database(cfg: Config, adapter: DbAdapter) -> None:
+    _section("Select Database Name")
+
+    console.print("  Existing databases on this server:")
+    all_dbs = adapter.list_databases()
+    if all_dbs:
+        tbl = Table(show_header=True, header_style="bold")
+        tbl.add_column("#", style="dim", width=4)
+        tbl.add_column("Database", min_width=28)
+        tbl.add_column("Size", justify="right")
+        for i, db in enumerate(all_dbs, 1):
+            tbl.add_row(str(i), db, adapter.get_db_size(db))
+        console.print(tbl)
+    else:
+        console.print("  [dim](no user databases yet)[/]")
+
+    console.print()
+    db_name = questionary.text("Enter name for the new database:").ask() or ""
+    db_name = db_name.strip()
+    if not db_name:
+        _die("Database name cannot be empty.")
+
+    # Check if it already exists
+    if adapter.db_exists(db_name):
+        _die(f"Database '{db_name}' already exists.")
+
+    # Confirm
+    console.print()
+    console.print(f"  [bold]Database:[/] [cyan]{db_name}[/] will be created.")
+    if not questionary.confirm("Create this database?", default=True).ask():
+        console.print("[yellow]Aborted.[/]")
+        sys.exit(0)
+
+    # Execute
+    console.print()
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("{task.description}", table_column=Column(min_width=48)),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        task = progress.add_task(f"[cyan]Creating database '{db_name}'…[/]", total=None)
+        try:
+            adapter.create_db(db_name)
+            progress.update(
+                task,
+                description=f"[green]✓ Database '{db_name}' created[/]",
+                total=1, completed=1,
+            )
+        except Exception as exc:
+            progress.update(task, description="[red]✗ Create failed[/]", total=1, completed=1)
+            _die(f"Create failed: {exc}")
+
+    console.print()
+    console.print(Panel(f"[bold green]DATABASE '{db_name}' CREATED[/]", expand=False))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+#  Schema creation (PostgreSQL only)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _create_schema(cfg: Config, adapter: DbAdapter) -> None:
+    # Pick the target database
+    _section("Select Database")
+
+    all_dbs = adapter.list_databases()
+    if not all_dbs:
+        _die("No databases found on server.")
+
+    db_name = questionary.select(
+        "Select database to create the schema in",
+        choices=[questionary.Choice(db, value=db) for db in all_dbs],
+    ).ask()
+
+    # List existing schemas in that database
+    _section("Schema Name")
+
+    schemas = adapter.get_user_schemas(db_name)
+    if schemas:
+        console.print("  Existing schemas in this database:")
+        tbl = Table(show_header=True, header_style="bold")
+        tbl.add_column("#", style="dim", width=4)
+        tbl.add_column("Schema", min_width=28)
+        for i, s in enumerate(schemas, 1):
+            tbl.add_row(str(i), s)
+        console.print(tbl)
+
+    console.print()
+    schema_name = questionary.text("Enter name for the new schema:").ask() or ""
+    schema_name = schema_name.strip()
+    if not schema_name:
+        _die("Schema name cannot be empty.")
+
+    if schema_name in schemas:
+        _die(f"Schema '{schema_name}' already exists in '{db_name}'.")
+
+    # Confirm
+    console.print()
+    console.print(f"  [bold]Schema:[/] [cyan]{schema_name}[/] in database [cyan]{db_name}[/] will be created.")
+    if not questionary.confirm("Create this schema?", default=True).ask():
+        console.print("[yellow]Aborted.[/]")
+        sys.exit(0)
+
+    # Execute
+    console.print()
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("{task.description}", table_column=Column(min_width=48)),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        task = progress.add_task(
+            f"[cyan]Creating schema '{schema_name}' in '{db_name}'…[/]",
+            total=None,
+        )
+        try:
+            adapter.create_schema(db_name, schema_name)
+            progress.update(
+                task,
+                description=f"[green]✓ Schema '{schema_name}' created in '{db_name}'[/]",
+                total=1, completed=1,
+            )
+        except Exception as exc:
+            progress.update(task, description="[red]✗ Create failed[/]", total=1, completed=1)
+            _die(f"Create failed: {exc}")
+
+    console.print()
+    console.print(Panel(
+        f"[bold green]SCHEMA '{schema_name}' CREATED IN '{db_name}'[/]",
+        expand=False,
+    ))

--- a/fuelrod_backup/drop.py
+++ b/fuelrod_backup/drop.py
@@ -28,6 +28,11 @@ def _die(msg: str) -> None:
     sys.exit(1)
 
 
+def _fmt(val: str) -> str:
+    """Return val or dimmed '?' if unknown."""
+    return val if val and val != "?" else "[dim]?[/]"
+
+
 def run_drop(cfg: Config) -> None:
     """Interactive wizard to drop a database or schema."""
     adapter = get_adapter(cfg)
@@ -92,10 +97,16 @@ def _drop_database(cfg: Config, adapter: DbAdapter) -> None:
 
     tbl = Table(show_header=True, header_style="bold")
     tbl.add_column("#", style="dim", width=4)
-    tbl.add_column("Database", min_width=28)
+    tbl.add_column("Database", min_width=24)
+    tbl.add_column("Tables", justify="right")
     tbl.add_column("Size", justify="right")
     for i, db in enumerate(all_dbs, 1):
-        tbl.add_row(str(i), db, adapter.get_db_size(db))
+        tbl.add_row(
+            str(i),
+            db,
+            _fmt(adapter.get_table_count(db)),
+            _fmt(adapter.get_db_size(db)),
+        )
     console.print(tbl)
 
     db_name: str = questionary.select(
@@ -103,12 +114,25 @@ def _drop_database(cfg: Config, adapter: DbAdapter) -> None:
         choices=[questionary.Choice(db, value=db) for db in all_dbs],
     ).ask()
 
+    # Gather summary details
+    table_count = adapter.get_table_count(db_name)
+    db_size = adapter.get_db_size(db_name)
+    schemas = adapter.get_user_schemas(db_name)
+
     # Confirm
     console.print()
-    console.print(
-        f"  [bold red]WARNING:[/] [bold]{db_name}[/] and ALL its data will be permanently deleted."
-    )
-    console.print("  All active connections will be terminated first.")
+    summary_parts = [
+        "[bold red]WARNING:[/] You are about to permanently delete:",
+        f"  [bold]{db_name}[/]",
+        f"  Tables : {_fmt(table_count)}",
+        f"  Size   : {_fmt(db_size)}",
+    ]
+    if schemas:
+        summary_parts.append(f"  Schemas: {len(schemas)}")
+    summary_parts.append("")
+    summary_parts.append("  All active connections will be terminated first.")
+    summary_parts.append("  [bold]This operation cannot be undone.[/]")
+    console.print("\n".join(summary_parts))
     console.print()
     typed = questionary.text(f'  Type "[bold]{db_name}[/]" to confirm:').ask() or ""
     if typed.strip() != db_name:
@@ -174,9 +198,14 @@ def _drop_schema(cfg: Config, adapter: DbAdapter) -> None:
 
     tbl = Table(show_header=True, header_style="bold")
     tbl.add_column("#", style="dim", width=4)
-    tbl.add_column("Schema", min_width=28)
+    tbl.add_column("Schema", min_width=24)
+    tbl.add_column("Tables", justify="right")
     for i, s in enumerate(schemas, 1):
-        tbl.add_row(str(i), s)
+        tbl.add_row(
+            str(i),
+            s,
+            _fmt(adapter.get_table_count(db_name, s)),
+        )
     console.print(tbl)
 
     schema_name: str = questionary.select(
@@ -184,13 +213,20 @@ def _drop_schema(cfg: Config, adapter: DbAdapter) -> None:
         choices=[questionary.Choice(s, value=s) for s in schemas],
     ).ask()
 
+    # Gather summary
+    table_count = adapter.get_table_count(db_name, schema_name)
+
     # Confirm
     console.print()
     console.print(
-        f"  [bold red]WARNING:[/] Schema [bold]{schema_name}[/] in database [bold]{db_name}[/] "
-        "will be permanently deleted."
+        "  [bold red]WARNING:[/] You are about to permanently delete:"
     )
+    console.print(f"    Schema   : [bold]{schema_name}[/]")
+    console.print(f"    Database : [bold]{db_name}[/]")
+    console.print(f"    Tables   : {_fmt(table_count)}")
+    console.print()
     console.print("  Every table, view, function and sequence inside it will be gone.")
+    console.print("  [bold]This operation cannot be undone.[/]")
     console.print()
     typed = questionary.text(f'  Type "[bold]{schema_name}[/]" to confirm:').ask() or ""
     if typed.strip() != schema_name:

--- a/fuelrod_backup/n8n_backup.py
+++ b/fuelrod_backup/n8n_backup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from datetime import datetime, timedelta
@@ -30,6 +31,18 @@ def _section(title: str) -> None:
 def _die(msg: str) -> None:
     console.print(f"[bold red]ERROR:[/] {msg}")
     sys.exit(1)
+
+
+_SAFE_SERVICE_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+
+def _validate_service(service: str) -> None:
+    """Ensure service name is safe for use in filesystem and docker commands."""
+    if not service or not _SAFE_SERVICE_RE.match(service):
+        _die(
+            f"Invalid service name '{service}': only letters, digits, "
+            "underscores, and hyphens are permitted."
+        )
 
 
 def _human_size(path: Path) -> str:
@@ -120,6 +133,7 @@ def _count_workflows(volume_name: str) -> str:
 
 def _backup_service(service: str, cfg: Config) -> None:
     """Perform a hot backup of one n8n Docker volume."""
+    _validate_service(service)
     volume_name = f"{service}-data"
 
     # Use base_dir / "n8n" / service  (not backup_dir which appends db_type)

--- a/fuelrod_backup/n8n_restore.py
+++ b/fuelrod_backup/n8n_restore.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import sys
@@ -32,6 +33,18 @@ def _section(title: str) -> None:
 def _die(msg: str) -> None:
     console.print(f"[bold red]ERROR:[/] {msg}")
     sys.exit(1)
+
+
+_SAFE_SERVICE_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+
+def _validate_service(service: str) -> None:
+    """Ensure service name is safe for use in filesystem and docker commands."""
+    if not service or not _SAFE_SERVICE_RE.match(service):
+        _die(
+            f"Invalid service name '{service}': only letters, digits, "
+            "underscores, and hyphens are permitted."
+        )
 
 
 def _human_size(path: Path) -> str:
@@ -79,6 +92,7 @@ def _select_service(cfg: Config) -> tuple[str, str, Path]:
         "Select service to restore", choices=choices
     ).ask()
 
+    _validate_service(selected_service)
     volume_name = f"{selected_service}-data"
     service_backup_dir = Path(cfg.base_dir) / "n8n" / selected_service
 
@@ -408,6 +422,7 @@ def run_n8n_restore(
 
     # Step 1 — Select service
     if service is not None:
+        _validate_service(service)
         volume_name = f"{service}-data"
         service_backup_dir = Path(cfg.base_dir) / "n8n" / service
         console.print(f"  Service : [bold]{service}[/]")

--- a/fuelrod_backup/restore.py
+++ b/fuelrod_backup/restore.py
@@ -566,7 +566,8 @@ def _execute_pg_restore_v2(
             work_file = tmp_plain
 
         if cfg.use_docker:
-            ctr_path = f"/tmp/pg_restore_{work_file.stem}.dump"  # noqa: S108
+            safe_stem = re.sub(r"[^A-Za-z0-9_.-]", "_", work_file.stem) or "dump"
+            ctr_path = f"/tmp/pg_restore_{safe_stem}.dump"  # noqa: S108
             subprocess.run(
                 ["docker", "cp", str(work_file), f"{cfg.service}:{ctr_path}"],
                 check=True,

--- a/fuelrod_backup/restore.py
+++ b/fuelrod_backup/restore.py
@@ -54,6 +54,15 @@ def _human_size(path: Path) -> str:
     return f"{size / 1024:.1f} KB"
 
 
+def _validate_resolved_path(resolved: Path, expected_base: Path) -> None:
+    """Ensure *resolved* is within *expected_base* to prevent symlink escape."""
+    if not str(resolved).startswith(str(expected_base.resolve())):
+        _die(
+            f"Path '{resolved}' is outside the expected base directory "
+            f"'{expected_base}'. Refusing to proceed."
+        )
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 #  TOC parsing helpers (PostgreSQL only)
 # ──────────────────────────────────────────────────────────────────────────────
@@ -184,8 +193,8 @@ def _step_select_top_dir(cfg: Config) -> Path:
     """Step 2: pick a top-level project/group folder from BASE_DIR."""
     _section("Step 2 — Select Project Directory")
 
-    base = Path(cfg.base_dir)
-    top_dirs = sorted([d for d in base.iterdir() if d.is_dir()])
+    base = Path(cfg.base_dir).resolve()
+    top_dirs = sorted([d for d in base.iterdir() if d.is_dir() and not d.is_symlink()])
     if not top_dirs:
         _die(f"No directories found in {base}")
 
@@ -200,6 +209,8 @@ def _step_select_top_dir(cfg: Config) -> Path:
 
     choices = [questionary.Choice(title=d.name, value=d) for d in top_dirs]
     top_dir: Path = questionary.select("Select directory", choices=choices).ask()
+    top_dir = top_dir.resolve()
+    _validate_resolved_path(top_dir, base)
     console.print(f"  Selected: [bold]{top_dir.name}[/]")
     return top_dir
 
@@ -219,7 +230,8 @@ def _step_select_database(engine_dir: Path) -> tuple[Path, str]:
     """Step 3: pick a database folder inside the engine dir."""
     _section("Step 3 — Select Database")
 
-    db_dirs = sorted([d for d in engine_dir.iterdir() if d.is_dir()])
+    engine_dir = engine_dir.resolve()
+    db_dirs = sorted([d for d in engine_dir.iterdir() if d.is_dir() and not d.is_symlink()])
     if not db_dirs:
         _die(f"No database folders found in {engine_dir}")
 
@@ -234,6 +246,8 @@ def _step_select_database(engine_dir: Path) -> tuple[Path, str]:
 
     choices = [questionary.Choice(title=d.name, value=d) for d in db_dirs]
     db_dir: Path = questionary.select("Select database", choices=choices).ask()
+    db_dir = db_dir.resolve()
+    _validate_resolved_path(db_dir, engine_dir)
     console.print(f"  Selected: [bold]{db_dir.name}[/]")
     return db_dir, db_dir.name
 

--- a/fuelrod_backup/runner.py
+++ b/fuelrod_backup/runner.py
@@ -10,6 +10,7 @@ PostgreSQL runner.
 from __future__ import annotations
 
 import gzip
+import re
 import shutil
 import subprocess
 import tempfile
@@ -179,7 +180,8 @@ class PgRunner:
                 work_file = tmp_plain
 
             if self.cfg.use_docker:
-                ctr_path = f"/tmp/pg_toc_{dump_file.stem}.dump"  # noqa: S108 — path is inside the container, not the host
+                safe_stem = re.sub(r"[^A-Za-z0-9_.-]", "_", dump_file.stem) or "dump"
+                ctr_path = f"/tmp/pg_toc_{safe_stem}.dump"  # noqa: S108 — path is inside the container, not the host
                 subprocess.run(
                     ["docker", "cp", str(work_file), f"{self.cfg.service}:{ctr_path}"],
                     check=True,

--- a/fuelrod_backup/runner.py
+++ b/fuelrod_backup/runner.py
@@ -326,6 +326,12 @@ class PgRunner:
             dbname=dbname,
         )
 
+    def create_schema(self, dbname: str, schema: str) -> None:
+        self._execute(
+            pgsql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(pgsql.Identifier(schema)),
+            dbname=dbname,
+        )
+
     def create_db(self, dbname: str, owner: str | None = None) -> None:
         if owner:
             stmt = pgsql.SQL("CREATE DATABASE {} OWNER {}").format(

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,14 +14,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.4.0"
+version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81"},
-    {file = "click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973"},
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
 
 [package.dependencies]
@@ -307,14 +307,14 @@ rsa = ["cryptography (>=46.0.7)"]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
@@ -396,30 +396,30 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruff"
-version = "0.15.13"
+version = "0.15.20"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8"},
-    {file = "ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7"},
-    {file = "ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629"},
-    {file = "ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5"},
-    {file = "ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22"},
-    {file = "ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9"},
-    {file = "ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55"},
-    {file = "ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6"},
-    {file = "ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca"},
-    {file = "ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd"},
-    {file = "ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6"},
-    {file = "ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51"},
-    {file = "ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2"},
-    {file = "ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b"},
-    {file = "ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41"},
-    {file = "ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4"},
-    {file = "ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21"},
-    {file = "ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7"},
+    {file = "ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078"},
+    {file = "ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b"},
+    {file = "ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632"},
+    {file = "ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd"},
+    {file = "ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b"},
+    {file = "ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267"},
+    {file = "ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c"},
+    {file = "ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae"},
+    {file = "ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b"},
+    {file = "ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487"},
+    {file = "ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3"},
+    {file = "ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053"},
+    {file = "ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4"},
+    {file = "ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460"},
+    {file = "ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21"},
+    {file = "ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415"},
+    {file = "ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca"},
+    {file = "ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566"},
 ]
 
 [[package]]
@@ -467,14 +467,14 @@ files = [
 
 [[package]]
 name = "wcwidth"
-version = "0.7.0"
+version = "0.8.2"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2"},
-    {file = "wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"},
+    {file = "wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85"},
+    {file = "wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda"},
 ]
 
 [metadata]


### PR DESCRIPTION
- Add `fuelrod-backup create` command for interactive database/schema creation
- Add `supports_schema_create` flag and `create_schema()` to DbAdapter + PgRunner
- Add `get_table_count()` to DbAdapter + MariaDB/MSSQL/PG adapters
- Improve drop wizard: show table/schema counts in listings, richer summary panels


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive command for creating databases and supported PostgreSQL schemas.
  - Added PostgreSQL schema creation support.
  - Database and schema removal screens now show table counts, sizes, and clearer warnings.

- **Improvements**
  - Configuration files are now discovered across user and project locations.
  - Initialization stores configuration in a user-specific default directory.
  - Database and schema statistics are displayed more consistently.

- **Bug Fixes & Security**
  - Added safeguards against unsafe names and path traversal during backup and restore operations.
  - Improved handling of missing configuration directories and Docker restore filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->